### PR TITLE
Add unit declarator to class declarations

### DIFF
--- a/lib/Text/Table/Simple.pm6
+++ b/lib/Text/Table/Simple.pm6
@@ -1,5 +1,5 @@
 use v6;
-class Text::Table::Simple;
+unit class Text::Table::Simple;
 
 constant %defaults = {
   rows => {


### PR DESCRIPTION
As of Rakudo 2015.05, the `unit` declarator is required before using
`module`, `class` or `grammar` declarations (unless it uses a block).  Code
still using the old blockless semicolon form will throw a warning. This
commit stops the warning from appearing in the new Rakudo.