### PR TITLE
Handle undefined values in cells

### DIFF
--- a/t/basics.t
+++ b/t/basics.t
@@ -1,6 +1,6 @@
 use v6;
 use Test;
-plan 5;
+plan 6;
 
 use Text::Table::Simple;
 
@@ -120,6 +120,29 @@ subtest {
     is @output, lol2table(@columns, @rows), 'Public api matches private api';
     is-deeply @output, @expected, 'Create a table (header + body)'
 }, "_build_table";
+
+# Test formatted table with undefined values
+subtest {
+    my @expected = (
+        'O----O----------O--O',
+        '| id | name     |  |',
+        'O====O==========O==O',
+        '|    | John Doe |  |',
+        '| 2  |          |  |',
+        '--------------------',
+    );
+    temp @columns = 'id', 'name', Str;
+    temp @rows = (
+        [Int,"John Doe",Str],
+        [2,Str,Failure.new],
+    );
+
+
+    my @output = _build_table( :header_rows(@columns), :body_rows(@rows) );
+
+    is @output, lol2table(@columns, @rows), 'Public api matches private api';
+    is-deeply @output, @expected, 'Create a table (header + body)'
+}, "_build_table with undefined values";
 
 
 done-testing;


### PR DESCRIPTION
- Change undefined values to empty strings
- Correct column width when undefined values are present

When I was trying to fix #8, I noticed the old code was not calculating the correct column width, apparently when `@r[*;$col]` was undefined `.max(*.chars)` would become `-Inf` and `.max(*.chars).chars` would become `4`, but it should have been `0`.