### PR TITLE
Add support for more specific corner markers

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,16 +1,17 @@
-os: Visual Studio 2015
+os: Visual Studio 2017
 
 platform: x64
 
 install:
-  - '"C:\Program Files\Microsoft SDKs\Windows\v7.1\Bin\SetEnv.cmd" /x64'
-  - choco install strawberryperl
+  - '"C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars64.bat"'
+  - appveyor-retry choco install strawberryperl --allow-empty-checksums
   - SET PATH=C:\strawberry\c\bin;C:\strawberry\perl\site\bin;C:\strawberry\perl\bin;%PATH%
-  - git clone https://github.com/rakudo/rakudo.git %APPVEYOR_BUILD_FOLDER%\..\rakudo
+  - appveyor-retry git clone https://github.com/rakudo/rakudo.git %APPVEYOR_BUILD_FOLDER%\..\rakudo
   - cd %APPVEYOR_BUILD_FOLDER%\..\rakudo
-  - perl Configure.pl --gen-moar --gen-nqp
+  - perl Configure.pl --gen-moar --gen-nqp --backends=moar
   - nmake install
   - SET PATH=%APPVEYOR_BUILD_FOLDER%\..\rakudo\install\bin;%PATH%
+  - SET PATH=%APPVEYOR_BUILD_FOLDER%\..\rakudo\install\share\perl6\site\bin;%PATH%
   - cd %APPVEYOR_BUILD_FOLDER%
 
 build: off

--- a/META6.json
+++ b/META6.json
@@ -1,5 +1,5 @@
 {
-    "perl"        : "6",
+    "perl"        : "6.c",
     "name"        : "Text::Table::Simple",
     "version"     : "0.0.7",
     "auth"        : "github:ugexe",
@@ -11,5 +11,5 @@
     },
     "source-url"  : "git://github.com/ugexe/Perl6-Text--Table--Simple.git",
     "authors"     : [ "Nick Logan" ],
-    "tags"        : [ "text", "terminal", "utils" ]
+    "tags"        : [ "text", "terminal", "utils", "table" ]
 }

--- a/README.pod
+++ b/README.pod
@@ -74,18 +74,42 @@ B<Options>
         },
     );
 
-You can replace any of the default options above by passing in a replacement
+You can replace any of the default options by passing in a replacement.
+C<corner_marker> is used when more specific corner markers are not set.
 
-    > my @cols = <XXX XXXX>;
-    > my @rows = ([1,2],[3,4]);
-    > .say for lol2table(@cols, @rows, rows => column_separator => "?"  );
+    > my %options =
+        rows => {
+            column_separator           => '│',
+            bottom_left_corner_marker  => '└',
+            bottom_right_corner_marker => '┘',
+            bottom_corner_marker       => '┴',
+            bottom_border              => '─',
+        },
+        headers => {
+            top_border                 => '═',
+            column_separator           => '│',
+            top_corner_marker          => '╤',
+            top_left_corner_marker     => '╒',
+            top_right_corner_marker    => '╕',
+            bottom_left_corner_marker  => '╞',
+            bottom_right_corner_marker => '╡',
+            bottom_corner_marker       => '╪',
+            bottom_border              => '═',
+        };
+    > my @columns = <id name email>;
+    > my @rows    = (
+        [1,"John Doe",'johndoe@cpan.org'],
+        [2,'Jane Doe','mrsjanedoe@hushmail.com'],
+    );
 
-    O-----O------O
-    | XXX | XXXX |
-    O=====O======O
-    ? 1   ? 2    ?
-    ? 3   ? 4    ?
-    --------------
+    > .put for lol2table(@columns, @rows, |%options);
+
+    ╒════╤══════════╤═════════════════════════╕
+    │ id │ name     │ email                   │
+    ╞════╪══════════╪═════════════════════════╡
+    │ 1  │ John Doe │ johndoe@cpan.org        │
+    │ 2  │ Jane Doe │ mrsjanedoe@hushmail.com │
+    └────┴──────────┴─────────────────────────┘
 
 =head3 Examples
 

--- a/examples/custom-separators.pl6
+++ b/examples/custom-separators.pl6
@@ -1,13 +1,24 @@
 use Text::Table::Simple;
 
-my %options = %(
-  rows => {
-      column_separator     => '?', # non-default
-  },
-  headers => {
-      bottom_border        => '~', # non-default
-  },
-);
+my %options =
+    rows => {
+        column_separator           => '│',
+        bottom_left_corner_marker  => '└',
+        bottom_right_corner_marker => '┘',
+        bottom_corner_marker       => '┴',
+        bottom_border              => '─',
+    },
+    headers => {
+        top_border                 => '═',
+        column_separator           => '│',
+        top_corner_marker          => '╤',
+        top_left_corner_marker     => '╒',
+        top_right_corner_marker    => '╕',
+        bottom_left_corner_marker  => '╞',
+        bottom_right_corner_marker => '╡',
+        bottom_corner_marker       => '╪',
+        bottom_border              => '═',
+    };
 
 my @columns = <id name email>;
 my @rows    = (
@@ -16,4 +27,4 @@ my @rows    = (
 );
 
 my @table = lol2table(@columns, @rows, |%options);
-$_.say for @table;
+.put for @table;

--- a/t/basics.t
+++ b/t/basics.t
@@ -1,33 +1,44 @@
-use v6;
+use v6.c;
 use Test;
-plan 6;
+plan 7;
 
 use Text::Table::Simple;
-
 
 my @columns = <id name email>;
 my @rows   = (
     [1,"John Doe",'johndoe@cpan.org'],
     [2,'Jane Doe','mrsjanedoe@hushmail.com'],
 );
-constant %options = {
-  rows => {
-      column_separator     => '|',
-      corner_marker        => '-',
-      bottom_border        => '-',
-  },
-  headers => {
-      top_border           => '-',
-      column_separator     => '|',
-      corner_marker        => 'O',
-      bottom_border        => '=',
-  },
-  footers => {
-      column_separator     => 'I',
-      corner_marker        => '%',
-      bottom_border        => '*',
-  },
-};
+my %options =
+    rows => {
+        column_separator           => '|',
+        corner_marker              => '-',
+        bottom_corner_marker       => '-',
+        bottom_left_corner_marker  => '-',
+        bottom_right_corner_marker => '-',
+        bottom_border              => '-',
+    },
+    headers => {
+        top_border                 => '-',
+        column_separator           => '|',
+        corner_marker              => 'O',
+        top_corner_marker          => 'O',
+        top_right_corner_marker    => 'O',
+        top_left_corner_marker     => 'O',
+        bottom_corner_marker       => 'O',
+        bottom_left_corner_marker  => 'O',
+        bottom_right_corner_marker => 'O',
+        bottom_border              => '=',
+    },
+    footers => {
+        column_separator           => 'I',
+        corner_marker              => '%',
+        bottom_corner_marker       => '%',
+        bottom_left_corner_marker  => '%',
+        bottom_right_corner_marker => '%',
+        bottom_border              => '*',
+    },
+;
 
 
 # Determine max column width
@@ -97,6 +108,53 @@ subtest {
     is @output, lol2table(@columns, @rows), 'Public api matches private api';
     is-deeply @output, @expected, 'Create a table (header + body)'
 }, "_build_table";
+
+# Test formatted table with custom options
+subtest {
+    my %custom_options = %(
+        rows => {
+            column_separator           => '│',
+            bottom_left_corner_marker  => '├',
+            bottom_right_corner_marker => '┤',
+            bottom_corner_marker       => '┼',
+            bottom_border              => '─',
+        },
+        headers => {
+            top_border                 => '═',
+            column_separator           => '│',
+            top_corner_marker          => '╤',
+            top_left_corner_marker     => '╒',
+            top_right_corner_marker    => '╕',
+            bottom_left_corner_marker  => '╞',
+            bottom_right_corner_marker => '╡',
+            bottom_corner_marker       => '╪',
+            bottom_border              => '═',
+        },
+        footers => {
+            column_separator           => '┃',
+            bottom_corner_marker       => '┻',
+            bottom_left_corner_marker  => '┗',
+            bottom_right_corner_marker => '┛',
+            bottom_border              => '━',
+        },
+    );
+    my @expected = (
+        '╒════╤══════════╤═════════════════════════╕',
+        '│ id │ name     │ email                   │',
+        '╞════╪══════════╪═════════════════════════╡',
+        '│ 1  │ John Doe │ johndoe@cpan.org        │',
+        '│ 2  │ Jane Doe │ mrsjanedoe@hushmail.com │',
+        '├────┼──────────┼─────────────────────────┤',
+        '┃ *  ┃ a        ┃ footer                  ┃',
+        '┗━━━━┻━━━━━━━━━━┻━━━━━━━━━━━━━━━━━━━━━━━━━┛',
+    );
+
+    my @footer = <* a footer>;
+    my @output = _build_table( :header_rows(@columns), :body_rows(@rows), :footer_rows(@footer), |%custom_options );
+
+    is @output, lol2table(@columns, @rows, @footer, |%custom_options), 'Public api matches private api';
+    is-deeply @output, @expected, 'Create a table (header + body + footer + custom options)'
+}, "_build_table with custom options and footer";
 
 # Test formatted table with multi-line cells
 subtest {


### PR DESCRIPTION
- Add support for top, bottom, top_left, bottom_right, ... corner markers
- Simplify `_build_options` sub and specially support the `corner_marker` option as default for all others
- Fix the mutability of the default options (inner containers)
- Small fixes and touches
- Add tests for new feature including a footer
- Update README and custom-separators example script

While I was testing, I hit a bug where setting custom options would change the default options! I was scratching my head for hours, then realized it's the mutability of inner hash containers that were causing it to be modified. I hope we see the immutability features for Raku soon!

I also went a little overboard and changed and touched some stuff. I hope that's not a problem.